### PR TITLE
Fix the peridnum variable

### DIFF
--- a/src/pycps/get_data.py
+++ b/src/pycps/get_data.py
@@ -146,7 +146,7 @@ def _build_df(raw_data: list[list[str]]) -> pd.DataFrame:
     cols = raw_data[1:]
 
     df = pd.DataFrame(data=cols, columns=col_names)
-    df = df.apply(pd.to_numeric)
+    df = df.apply(pd.to_numeric, errors='ignore')
 
     return df
 


### PR DESCRIPTION
The `PERIDNUM` variable looks like: 7600950111139642000000

This is too big to fit into a 64bit integer. Therefore, to make it work I've opted to ignore the errors which makes it stay as a string.